### PR TITLE
Items ready to ship

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -6,4 +6,11 @@ class Merchant < ApplicationRecord
   has_many :transactions, through: :invoices
 
   validates :name, presence: true
+
+  def items_ready_to_ship
+    Merchant.joins(invoice_items: [invoice: :transactions]).
+    where(merchants: {id: self.id}, invoice_items: {status: [0,2]}, invoices: {status: [1,2]}, transactions: {result: true}).
+    select("items.name, invoices.id, invoices.created_at").
+    order("invoices.created_at ASC")
+  end
 end

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -13,3 +13,16 @@
   <% end %>
   </ol>
 </div>
+
+
+<div class= "items_ready_to_ship">
+  <h3>Items Ready to Ship:</h3>
+  <ol>
+    <% @merchant.items_ready_to_ship.each do |item| %>
+    <div id="item-<%= item.id %>">
+      <li><b> <%= "#{item.name}" %></b></li>
+      <p> <%= link_to "#{item.id}", "/merchants/invoices/#{item.id}" %>
+      </div>
+      <% end %>
+    </ol>
+  </div>

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -21,7 +21,8 @@
     <% @merchant.items_ready_to_ship.each do |item| %>
     <div id="item-<%= item.id %>">
       <li><b> <%= "#{item.name}" %></b></li>
-      <p> <%= link_to "#{item.id}", "/merchants/invoices/#{item.id}" %>
+      <p> <%= link_to "#{item.id}", "/merchants/invoices/#{item.id}" %> </p>
+      <p> <%= item.created_at.strftime("Invoice Date %A, %B %d, %Y") %> </p>
       </div>
       <% end %>
     </ol>

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -116,4 +116,16 @@ RSpec.describe 'merchant dashboard show' do
 
     end
   end
+
+  it "displays all merchant items ready to ship" do
+    visit "/merchants/#{merchant1.id}/dashboard"
+
+    expect(page).to have_content("Items Ready to Ship:")
+    within ".items_ready_to_ship" do
+      expect(page).to have_content("#{item2.name}")
+      expect(page).to have_link("#{invoice3.id}")
+      expect(page).to have_link("#{invoice4.id}")
+    end
+
+  end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -12,4 +12,39 @@ RSpec.describe Merchant do
   describe 'validations' do
     it { should validate_presence_of(:name) }
   end
+
+  describe 'instance methods' do
+    it 'items_ready_to_ship should return array of items ready to ship ordered by invoice date' do
+      merchant1 = Merchant.create!(name: "Schroeder-Jerde")
+
+      item1 = merchant1.items.create!(name: "Qui Esse", description: "Nihil autem sit odio inventore deleniti", unit_price: 75107)
+      item2 = merchant1.items.create!(name: "Autem Minima", description: "Cumque consequuntur ad", unit_price: 67076)
+
+      customer1 = Customer.create!(first_name: "Leanne", last_name: "Braun")
+      customer2 = Customer.create!(first_name: "Sylvester", last_name: "Nader")
+      customer3 = Customer.create!(first_name: "Heber", last_name: "Kuhn")
+
+      invoice2 = customer2.invoices.create!(status: "completed")
+      invoice3 = customer3.invoices.create!(status: "in progress")
+      invoice4 = customer2.invoices.create!(status: "completed")
+      invoice5 = customer1.invoices.create!(status: "completed")
+      invoice1 = customer1.invoices.create!(status: "in progress")
+
+      invoice_item1 = InvoiceItem.create!(item_id: item1.id, invoice_id: invoice1.id, quantity: 5, unit_price: 13635, status: "packaged")
+      invoice_item2 = InvoiceItem.create!(item_id: item1.id, invoice_id: invoice2.id, quantity: 9, unit_price: 23324, status: "pending")
+      invoice_item3 = InvoiceItem.create!(item_id: item2.id, invoice_id: invoice3.id, quantity: 8, unit_price: 34873, status: "packaged")
+      invoice_item4 = InvoiceItem.create!(item_id: item2.id, invoice_id: invoice4.id, quantity: 3, unit_price: 2196, status: "packaged")
+      invoice_item5 = InvoiceItem.create!(item_id: item2.id, invoice_id: invoice5.id, quantity: 7, unit_price: 79140, status: "shipped")
+
+      transaction1 = Transaction.create!(invoice_id: invoice1.id, credit_card_number: 4654405418249632, credit_card_expiration_date: "2/22", result: "success")
+      transaction2 = Transaction.create!(invoice_id: invoice2.id, credit_card_number: 4580251236515201, credit_card_expiration_date: "1/22", result: "failed")
+      transaction3 = Transaction.create!(invoice_id: invoice3.id, credit_card_number: 4354495077693036, credit_card_expiration_date: "10/22", result: "success")
+      transaction4 = Transaction.create!(invoice_id: invoice4.id, credit_card_number: 4515551623735607, credit_card_expiration_date: "4/25", result: "success")
+      transaction5 = Transaction.create!(invoice_id: invoice5.id, credit_card_number: 4844518708741275, credit_card_expiration_date: "4/23", result: "success")
+
+      expect(merchant1.items_ready_to_ship.first.id).to eq(invoice3.id)
+      expect(merchant1.items_ready_to_ship.first.name).to eq("#{item2.name}")
+      expect(merchant1.items_ready_to_ship.first.created_at).to eq(invoice3.created_at)
+    end
+  end
 end


### PR DESCRIPTION
### What does this PR do?
User Stories #37 and #36. This PR creates an "items ready to ship" section which displays items that:

- have not yet shipped
- the transaction is successful
- invoice status is 'in progress' or 'completed'

next to each item is the item name, a link to the merchant invoice page, and the date in which the invoice was created (ordered by oldest to newest).

### All tests passing?
- [ ] Yes
- [X] No
This is failing the favorite customers block which I believe was fixed in another pull request.
### SimpleCov 100%?
- [ ] Yes
- [X] No
- If No, what's missing:
favorite customers section. Without that, the coverage is at 100%
### Has this been tested on LOCALHOST?
- [X] Yes
- [ ] No
- Did something not work? If so, what was it?
