### PR TITLE
Invoice show update item

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -6,7 +6,7 @@ class InvoicesController < ApplicationController
   end
 
   def show
-    @invoice = Invoice.find(params[:id])
+    @invoices = Invoice.invoices_with_merchant_items(@merchant)
   end
 
   def update

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -2,11 +2,11 @@ class InvoicesController < ApplicationController
   before_action :find_merchant
 
   def index
-    @invoices = @merchant.invoices
+    @invoices = Invoice.invoices_with_merchant_items(@merchant)
   end
 
   def show
-    @invoices = Invoice.invoices_with_merchant_items(@merchant)
+    @invoice = Invoice.find(params[:id])
   end
 
   def update

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -8,4 +8,16 @@ class InvoicesController < ApplicationController
   def show
     @invoice = Invoice.find(params[:id])
   end
+
+  def update
+    invoice = Invoice.find(params[:id])
+    invoice_item = InvoiceItem.find(params[:invoice_item_id])
+    invoice_item.update(invoice_item_params)
+    redirect_to merchant_invoice_path(@merchant, invoice)
+  end
+
+  private
+    def invoice_item_params
+      params.permit(:status)
+    end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -16,4 +16,8 @@ class Invoice < ApplicationRecord
   def total_revenue
     invoice_items.sum('invoice_items.unit_price * invoice_items.quantity')
   end
+
+  def self.invoices_with_merchant_items(merchant)
+    merchant.invoices.distinct(:id)
+  end
 end

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -8,12 +8,19 @@
 <h2>Invoice Items</h2>
 <div class="invoice_items">
   <% @invoice.invoice_items.each do |invoice_item| %>
+  <div id="<%= invoice_item.id %>">
     <h4>Item Name: <%= invoice_item.item.name %></h4>
     <p>Quantity Sold: <%= invoice_item.quantity %></p>
     <p>Sold at: <%= number_to_currency(invoice_item.unit_price) %></p>
     <p>Invoice Item Status: <%= invoice_item.status.titleize %></p>
-    <hr>
+      <%= form_with url: merchant_invoice_path(@merchant, @invoice), method: :patch do |form| %>
+        <%= form.select :status, ['pending', 'shipped', 'packaged'], selected: invoice_item.status %>
+        <%= hidden_field_tag "invoice_item_id", "#{invoice_item.id}" %>
+        <%= form.submit "Update Invoice Item Status" %>
+      <% end %>
+  </div>
+  <hr>
   <% end %>
 </div>
 
-Total Revenue: <%= number_to_currency(@invoice.total_revenue) %>
+<p><b>Total Revenue:</b> <%= number_to_currency(@invoice.total_revenue) %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   resources :merchants, except: [:show] do
     resources :items, only: [:index, :show, :edit, :update, :new, :create]
-    resources :invoices, only: [:index, :show]
+    resources :invoices, only: [:index, :show, :update]
   end
 
   namespace :admin do

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Merchant Invoices Show Page" do
     expect(page).to have_content("Created at: #{invoice1.created_at.strftime("%A, %B %d, %Y")}")
 
     expect(page).to_not have_content("Invoice ##{invoice2.id}")
-    expect(page).to_not have_content("Status: Completed")
+    expect(page).to_not have_content("Status: completed")
 
     within ".customer" do
       expect(page).to have_content("Customer Name: Leanne Braun")
@@ -105,7 +105,6 @@ RSpec.describe "Merchant Invoices Show Page" do
       expect(page).to have_content("Sold at: $13,635.00")
       expect(page).to have_content("Invoice Item Status: Packaged")
 
-
       expect(page).to have_content("Item Name: Autem Minima")
       expect(page).to have_content("Quantity Sold: 9")
       expect(page).to have_content("Sold at: $23,324.00")
@@ -120,5 +119,22 @@ RSpec.describe "Merchant Invoices Show Page" do
     visit merchant_invoice_path(merchant1, invoice1)
 
     expect(page).to have_content("Total Revenue: $278,091.00")
+  end
+
+  it "can update and Invoice Item's status via a selector" do
+    visit merchant_invoice_path(merchant1, invoice1)
+
+    within "##{invoice_item1.id}" do
+      select "#{invoice_item1.status}"
+      select "shipped"
+      expect(page).to have_button("Update Invoice Item Status")
+
+      click_button "Update Invoice Item Status"
+      expect(page).to have_select(selected: "shipped")
+      expect(page).to_not have_select(selected: "packaged")
+      expect(page).to_not have_select(selected: "pending")
+    end
+
+    expect(current_path).to eq(merchant_invoice_path(merchant1, invoice1))
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -13,6 +13,48 @@ RSpec.describe Invoice do
     it { should validate_presence_of(:status) }
   end
 
+  describe "class methods" do
+    let!(:merchant1) { Merchant.create!(name: "Schroeder-Jerde") }
+    let!(:merchant2) { Merchant.create!(name: "Klein, Rempel and Jones") }
+
+    let!(:item1) { merchant1.items.create!(name: "Qui Esse", description: "Nihil autem sit odio inventore deleniti", unit_price: 75107) }
+    let!(:item2) { merchant1.items.create!(name: "Autem Minima", description: "Cumque consequuntur ad", unit_price: 67076) }
+    let!(:item3) { merchant2.items.create!(name: "Ea Voluptatum", description: "Sunt officia", unit_price: 68723) }
+
+    let!(:invoice1) { customer1.invoices.create!(status: "cancelled") }
+    let!(:invoice2) { customer2.invoices.create!(status: "completed") }
+    let!(:invoice3) { customer3.invoices.create!(status: "in progress") }
+    let!(:invoice4) { customer4.invoices.create!(status: "completed") }
+    let!(:invoice5) { customer5.invoices.create!(status: "completed") }
+    let!(:invoice6) { customer5.invoices.create!(status: "in progress") }
+
+    let!(:invoice_item1) { InvoiceItem.create!(item_id: item1.id, invoice_id: invoice1.id, quantity: 5, unit_price: 13635, status: "packaged") }
+    let!(:invoice_item2) { InvoiceItem.create!(item_id: item1.id, invoice_id: invoice2.id, quantity: 9, unit_price: 23324, status: "pending") }
+    let!(:invoice_item3) { InvoiceItem.create!(item_id: item2.id, invoice_id: invoice3.id, quantity: 8, unit_price: 34873, status: "packaged") }
+    let!(:invoice_item4) { InvoiceItem.create!(item_id: item2.id, invoice_id: invoice4.id, quantity: 3, unit_price: 2196, status: "packaged") }
+    let!(:invoice_item5) { InvoiceItem.create!(item_id: item2.id, invoice_id: invoice5.id, quantity: 7, unit_price: 79140, status: "shipped") }
+    let!(:invoice_item6) { InvoiceItem.create!(item_id: item3.id, invoice_id: invoice6.id, quantity: 3, unit_price: 52100, status: "packaged") }
+
+    let!(:customer1) { Customer.create!(first_name: "Leanne", last_name: "Braun") }
+    let!(:customer2) { Customer.create!(first_name: "Sylvester", last_name: "Nader") }
+    let!(:customer3) { Customer.create!(first_name: "Heber", last_name: "Kuhn") }
+    let!(:customer4) { Customer.create!(first_name: "Mariah", last_name: "Toy") }
+    let!(:customer5) { Customer.create!(first_name: "Carl", last_name: "Junior") }
+    let!(:customer6) { Customer.create!(first_name: "Tony", last_name: "Bologna") }
+
+    let!(:transaction1) { Transaction.create!(invoice_id: invoice1.id, credit_card_number: 4654405418249632, credit_card_expiration_date: "2/22", result: "success") }
+    let!(:transaction2) { Transaction.create!(invoice_id: invoice2.id, credit_card_number: 4580251236515201, credit_card_expiration_date: "1/22", result: "failed") }
+    let!(:transaction3) { Transaction.create!(invoice_id: invoice3.id, credit_card_number: 4354495077693036, credit_card_expiration_date: "10/22", result: "success") }
+    let!(:transaction4) { Transaction.create!(invoice_id: invoice4.id, credit_card_number: 4515551623735607, credit_card_expiration_date: "4/25", result: "success") }
+    let!(:transaction5) { Transaction.create!(invoice_id: invoice5.id, credit_card_number: 4844518708741275, credit_card_expiration_date: "4/23", result: "success") }
+    let!(:transaction6) { Transaction.create!(invoice_id: invoice6.id, credit_card_number: 4203696133194408, credit_card_expiration_date: "5/22", result: "success") }
+
+    it ".invoices_with_merchant_items(merchant)" do
+      expect(Invoice.invoices_with_merchant_items(merchant1)).to eq([invoice1, invoice2, invoice3, invoice4, invoice5])
+      expect(Invoice.invoices_with_merchant_items(merchant1)).to_not eq([invoice6])
+    end
+  end
+
   describe "instance methods" do
     it "#invoice_customer" do
       customer1 = Customer.create!(first_name: "Leanne", last_name: "Braun")

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Merchant do
       it "lists the top five items ordered in highest to lowest revenue" do
         expect(merchant_1.top_five_items).to eq([item1, item2, item6, item3, item4])
       end
+    end  
 
     it 'items_ready_to_ship should return array of items ready to ship ordered by invoice date' do
       merchant1 = Merchant.create!(name: "Schroeder-Jerde")


### PR DESCRIPTION
### What does this PR do?
- Completes User Story #23 
- From a Merchant's Invoice Show Page, a selector field now exists that changes the status of an `Invoice Item` to `'packaged', 'pending', or 'shipped'`
- This branch also reinstates an Invoice model method that narrows the overall Invoices search from the Merchant Invoices Index to distinct Invoices relative to the Merchant. Previously, the Index page displayed all Invoices with unique Merchant Items, thus causing the same Invoice to repeat many times upon the page, relative to how many unique Merchant Items would be present on that Invoice.

### All tests passing?
- [X] Yes
- [ ] No

### SimpleCov 100%?
- [X] Yes
- [ ] No
- If No, what's missing:

### Has this been tested on LOCALHOST?
- [X] Yes
- [ ] No
- Did something not work? If so, what was it?
