### PR TITLE
Feature: Incomplete invoices ordered by oldest to newest. 

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,6 +1,6 @@
 class AdminController < ApplicationController
 
   def index
-    @invoice_items = InvoiceItem.all
+    @invoices = Invoice.all
   end
 end

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -8,4 +8,5 @@ class InvoicesController < ApplicationController
   def show
     @invoice = Invoice.find(params[:id])
   end
+  
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -16,4 +16,11 @@ class Invoice < ApplicationRecord
   def total_revenue
     invoice_items.sum('invoice_items.unit_price * invoice_items.quantity')
   end
+
+  def self.incomplete_invoices
+    joins(:invoice_items)
+    .where.not(invoice_items: {status: 1})
+    .distinct
+    .order(:created_at)
+  end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -7,8 +7,4 @@ class InvoiceItem < ApplicationRecord
   validates :status, presence: true
 
   enum status: {'pending' => 0, 'shipped' => 1, 'packaged' => 2}
-
-  def self.incomplete_invoice_ids
-    where.not(status: 1).distinct.pluck(:invoice_id)
-  end
 end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -4,8 +4,8 @@
 
 <div class ="incomplete-invoices">
   <h3> Incomplete Invoices </h3>
-  <ul><% @invoice_items.incomplete_invoice_ids.each do |id| %>
-      <li> <%= link_to "#{id}", admin_invoice_path(id) %> </li>
+  <ul><% @invoices.incomplete_invoices.each do |invoice| %>
+      <li> <%= link_to "#{invoice.id}", admin_invoice_path(invoice) %> <i>Created on: <%= invoice.created_at.strftime("%A, %d %b %Y") %> </i></li>
   <% end %></ul>
 
 </div>

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -5,9 +5,10 @@ describe "Admin Dashboad" do
 
   let!(:customer1) { Customer.create!(first_name: "Leanne", last_name: "Braun") }
 
-  let!(:invoice1) { customer1.invoices.create!(status: 2) }
-  let!(:invoice2) { customer1.invoices.create!(status: 2) }
-  let!(:invoice3) { customer1.invoices.create!(status: 2) }
+  let!(:invoice1) { customer1.invoices.create!(status: 2, created_at: '2012-03-21 14:53:59') }
+  let!(:invoice2) { customer1.invoices.create!(status: 2, created_at: '2012-03-23 14:53:59') }
+  let!(:invoice3) { customer1.invoices.create!(status: 2, created_at: '2012-03-24 14:53:59') }
+  let!(:invoice4) { customer1.invoices.create!(status: 2, created_at: '2012-03-25 14:53:59') }
 
   let!(:item1) {merchant_1.items.create!(name: "Boots", description: "Never get blisters again!", unit_price: 135)}
   let!(:item2) {merchant_1.items.create!(name: "Tent", description: "Will survive any storm", unit_price: 219.99)}
@@ -17,6 +18,7 @@ describe "Admin Dashboad" do
   let!(:invoice_item2) { InvoiceItem.create!(item_id: item1.id, invoice_id: invoice1.id, quantity: 10, unit_price: 130, status: "pending") }
   let!(:invoice_item3) { InvoiceItem.create!(item_id: item2.id, invoice_id: invoice2.id, quantity: 8, unit_price: 220, status: "packaged") }
   let!(:invoice_item4) { InvoiceItem.create!(item_id: item3.id, invoice_id: invoice3.id, quantity: 1, unit_price: 100, status: "shipped") }
+  let!(:invoice_item5) { InvoiceItem.create!(item_id: item3.id, invoice_id: invoice4.id, quantity: 1, unit_price: 100, status: "packaged") }
 
   before do
     visit admin_index_path
@@ -40,11 +42,16 @@ describe "Admin Dashboad" do
     within ".incomplete-invoices" do
       expect(page).to have_link("#{invoice1.id}")
       expect(page).to have_link("#{invoice2.id}")
+      expect(page).to have_link("#{invoice4.id}")
       expect(page).to_not have_link("#{invoice3.id}")
 
       click_link("#{invoice1.id}")
       expect(current_path).to eq(admin_invoice_path(invoice1))
     end
+  end
 
+  it "orders incomplete invoices by oldest to newest" do
+    expect("#{invoice1.id}").to appear_before("#{invoice2.id}")
+    expect("#{invoice2.id}").to appear_before("#{invoice4.id}")
   end
 end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -11,33 +11,4 @@ RSpec.describe InvoiceItem do
     it { should validate_presence_of(:unit_price) }
     it { should validate_presence_of(:status) }
   end
-
-  describe 'class methods' do
-    let!(:merchant_1) {Merchant.create!(name: "REI")}
-
-    let!(:customer1) { Customer.create!(first_name: "Leanne", last_name: "Braun") }
-
-    let!(:invoice1) { customer1.invoices.create!(status: 2) }
-    let!(:invoice2) { customer1.invoices.create!(status: 2) }
-    let!(:invoice3) { customer1.invoices.create!(status: 2) }
-
-    let!(:item1) {merchant_1.items.create!(name: "Boots", description: "Never get blisters again!", unit_price: 135)}
-    let!(:item2) {merchant_1.items.create!(name: "Tent", description: "Will survive any storm", unit_price: 219.99)}
-    let!(:item3) {merchant_1.items.create!(name: "Backpack", description: "Can carry all your hiking snacks", unit_price: 99)}
-
-    let!(:invoice_item1) { InvoiceItem.create!(item_id: item1.id, invoice_id: invoice1.id, quantity: 5, unit_price: 130, status: "shipped") }
-    let!(:invoice_item2) { InvoiceItem.create!(item_id: item1.id, invoice_id: invoice1.id, quantity: 10, unit_price: 130, status: "pending") }
-    let!(:invoice_item3) { InvoiceItem.create!(item_id: item2.id, invoice_id: invoice2.id, quantity: 8, unit_price: 220, status: "packaged") }
-    let!(:invoice_item4) { InvoiceItem.create!(item_id: item3.id, invoice_id: invoice3.id, quantity: 1, unit_price: 100, status: "shipped") }
-
-    describe '.incomplete_invoice_ids' do
-      it 'returns the ids of invoices with items that have not yet been shipped (are pending or packaged)' do
-        expect(InvoiceItem.incomplete_invoice_ids).to include(invoice2.id)
-        expect(InvoiceItem.incomplete_invoice_ids).to include(invoice1.id)
-        expect(InvoiceItem.incomplete_invoice_ids).to_not include(invoice3.id)
-      end
-    end
-  end
-
-
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -31,8 +31,36 @@ RSpec.describe Invoice do
 
       invoice_item1 = InvoiceItem.create!(item_id: item1.id, invoice_id: invoice1.id, quantity: 5, unit_price: 195, status: "packaged")
       invoice_item2 = InvoiceItem.create!(item_id: item2.id, invoice_id: invoice1.id, quantity: 3, unit_price: 130, status: "packaged")
-# require "pry"; binding.pry
+
       expect(invoice1.total_revenue).to eq(1365)
+    end
+  end
+
+
+    describe 'class methods' do
+      let!(:merchant_1) {Merchant.create!(name: "REI")}
+
+      let!(:customer1) { Customer.create!(first_name: "Leanne", last_name: "Braun") }
+
+      let!(:invoice1) { customer1.invoices.create!(status: 2, created_at: '2012-03-21 14:53:59') }
+      let!(:invoice2) { customer1.invoices.create!(status: 2, created_at: '2012-03-23 14:53:59') }
+      let!(:invoice3) { customer1.invoices.create!(status: 2, created_at: '2012-03-24 14:53:59') }
+      let!(:invoice4) { customer1.invoices.create!(status: 2, created_at: '2012-03-25 14:53:59') }
+
+      let!(:item1) {merchant_1.items.create!(name: "Boots", description: "Never get blisters again!", unit_price: 135)}
+      let!(:item2) {merchant_1.items.create!(name: "Tent", description: "Will survive any storm", unit_price: 219.99)}
+      let!(:item3) {merchant_1.items.create!(name: "Backpack", description: "Can carry all your hiking snacks", unit_price: 99)}
+
+      let!(:invoice_item1) { InvoiceItem.create!(item_id: item1.id, invoice_id: invoice1.id, quantity: 5, unit_price: 130, status: "shipped") }
+      let!(:invoice_item2) { InvoiceItem.create!(item_id: item1.id, invoice_id: invoice1.id, quantity: 10, unit_price: 130, status: "pending") }
+      let!(:invoice_item3) { InvoiceItem.create!(item_id: item2.id, invoice_id: invoice2.id, quantity: 8, unit_price: 220, status: "packaged") }
+      let!(:invoice_item4) { InvoiceItem.create!(item_id: item3.id, invoice_id: invoice3.id, quantity: 1, unit_price: 100, status: "shipped") }
+      let!(:invoice_item5) { InvoiceItem.create!(item_id: item3.id, invoice_id: invoice4.id, quantity: 1, unit_price: 100, status: "packaged") }
+
+    describe '.incomplete_invoices' do
+      it 'returns the invoices with items that have not yet been shipped, ordered from oldest to newest' do
+        expect(Invoice.incomplete_invoices).to eq([invoice1, invoice2, invoice4])
+      end
     end
   end
 end


### PR DESCRIPTION
### What does this PR do?
Completes #18.  I had to refactor my incomplete invoices method because it was returning just the ID through invoice items for user story #19 , but in order to complete this user story and order the invoices by created_at date, I needed to be able to access the entire invoice object. So the method had to be moved to the invoice model, refactored, and then refactored the tests/views to accomodate for this change. 

### All tests passing?
- [] Yes
- [x] No
- All tests relevant to what I am working on are passing, but there is a skipped test I think from something Zac is working on.

### SimpleCov 100%?
- [ ] Yes
- [x] No
- If No, what's missing: There is a skipped test in here as previously mentioned, but aside from this coverage is 100%

### Has this been tested on LOCALHOST?
- [x] Yes
- [ ] No
- Did something not work? If so, what was it?
