### PR TITLE
Merchant favorite customers

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -7,16 +7,6 @@ class Customer < ApplicationRecord
 
   validates_presence_of :first_name, :last_name
 
-  # TODO: refactor these methods they are basically the same
-
-  def self.favorite_customers(count)
-    joins(invoices: :transactions).
-    where(transactions: {result: true}).
-    group(:id).select('customers.*, COUNT(transactions.created_at)').
-    order('count desc').
-    limit(count)
-  end
-
   def self.count_successful_transactions(id)
     Customer.find(id).transactions.where(result: true).count
   end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -7,10 +7,6 @@ class Customer < ApplicationRecord
 
   validates_presence_of :first_name, :last_name
 
-  def self.count_successful_transactions(id)
-    Customer.find(id).transactions.where(result: true).count
-  end
-
   def self.top_customers
     joins(invoices: :transactions)
     .where(transactions: {result: true})

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -23,4 +23,13 @@ class Merchant < ApplicationRecord
     .order('revenue desc')
     .limit(5)
   end
+
+  def top_five_favorite_customers
+    customers.joins(invoices: :transactions)
+    .where(transactions: { result: true })
+    .select('customers.*, count(transactions.*) as transaction_count')
+    .group('customers.id')
+    .order(transaction_count: :desc)
+    .limit(5)
+  end
 end

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -5,10 +5,10 @@
 <div class= "favorite_customers">
   <h3>Top 5 Favorite Customers:</h3>
   <ol>
-  <% Customer.favorite_customers(5).each do |customer| %>
+  <% @merchant.top_five_favorite_customers.each do |customer| %>
     <div id="customer-<%= customer.id %>">
       <li><b> <%= "#{customer.first_name} #{customer.last_name}" %></b>,
-      <%= Customer.count_successful_transactions(customer.id) %> Successful Transactions</li>
+      <%= customer.transaction_count %> Successful Transactions</li>
     </div>
   <% end %>
   </ol>

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -109,7 +109,7 @@ describe "Admin Dashboad" do
 
   it "lists the names of the top 5 customers with the largest number of successful transactions" do
     within ".top-five-customers" do
-      save_and_open_page
+
       expect("Leanne Braun").to appear_before("Mariah Toy")
       expect("Mariah Toy").to appear_before("Carl Junior")
       expect("Carl Junior").to appear_before("Tony Bologna")

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe 'merchant dashboard show' do
   let!(:invoice_item6) { InvoiceItem.create!(item_id: item3.id, invoice_id: invoice6.id, quantity: 3, unit_price: 52100, status: "packaged") }
   let!(:invoice_item7) { InvoiceItem.create!(item_id: item4.id, invoice_id: invoice7.id, quantity: 7, unit_price: 13635, status: "packaged") }
   let!(:invoice_item8) { InvoiceItem.create!(item_id: item5.id, invoice_id: invoice8.id, quantity: 2, unit_price: 23324, status: "pending") }
-  let!(:invoice_item9) { InvoiceItem.create!(item_id: item5.id, invoice_id: invoice9.id, quantity: 4, unit_price: 34873, status: "packaged") }
-  let!(:invoice_item10) { InvoiceItem.create!(item_id: item5.id, invoice_id: invoice10.id, quantity: 8, unit_price: 2196, status: "packaged") }
-  let!(:invoice_item11) { InvoiceItem.create!(item_id: item5.id, invoice_id: invoice11.id, quantity: 8, unit_price: 2196, status: "packaged") }
+  let!(:invoice_item9) { InvoiceItem.create!(item_id: item2.id, invoice_id: invoice9.id, quantity: 4, unit_price: 34873, status: "packaged") }
+  let!(:invoice_item10) { InvoiceItem.create!(item_id: item2.id, invoice_id: invoice10.id, quantity: 8, unit_price: 2196, status: "packaged") }
+  let!(:invoice_item11) { InvoiceItem.create!(item_id: item2.id, invoice_id: invoice11.id, quantity: 8, unit_price: 2196, status: "packaged") }
   let!(:invoice_item12) { InvoiceItem.create!(item_id: item3.id, invoice_id: invoice12.id, quantity: 3, unit_price: 52100, status: "packaged") }
   let!(:invoice_item13) { InvoiceItem.create!(item_id: item4.id, invoice_id: invoice13.id, quantity: 7, unit_price: 13635, status: "packaged") }
   let!(:invoice_item14) { InvoiceItem.create!(item_id: item5.id, invoice_id: invoice14.id, quantity: 2, unit_price: 23324, status: "pending") }
@@ -101,17 +101,17 @@ RSpec.describe 'merchant dashboard show' do
     visit "/merchants/#{merchant1.id}/dashboard"
 
     expect(page).to have_content("Top 5 Favorite Customers:")
-
+save_and_open_page
     within ".favorite_customers" do
+      expect(page).to have_content("Tony Bologna, 9 Successful Transactions")
       expect(page).to have_content("Mariah Toy, 5 Successful Transactions")
       expect(page).to have_content("Carl Junior, 4 Successful Transactions")
-      expect(page).to have_content("Tony Bologna, 3 Successful Transactions")
       expect(page).to have_content("Leanne Braun, 2 Successful Transactions")
       expect(page).to have_content("Heber Kuhn, 1 Successful Transactions")
 
+      expect("Tony Bologna").to appear_before("Mariah Toy")
       expect("Mariah Toy").to appear_before("Carl Junior")
-      expect("Carl Junior").to appear_before("Tony Bologna")
-      expect("Tony Bologna").to appear_before("Leanne Braun")
+      expect("Carl Junior").to appear_before("Leanne Braun")
       expect("Leanne Braun").to appear_before("Heber Kuhn")
     end
   end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe 'merchant dashboard show' do
     visit "/merchants/#{merchant1.id}/dashboard"
 
     expect(page).to have_content("Top 5 Favorite Customers:")
-save_and_open_page
+
     within ".favorite_customers" do
       expect(page).to have_content("Tony Bologna, 9 Successful Transactions")
       expect(page).to have_content("Mariah Toy, 5 Successful Transactions")

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -14,63 +14,7 @@ RSpec.describe Customer do
     it { should validate_presence_of(:last_name) }
   end
 
-  describe "::favorite_customers" do
-    it "tracks a merchant's favorite customers" do
-      customer1 = Customer.create!(first_name: 'Zach', last_name: 'Hazelwood')
-      customer2 = Customer.create!(first_name: 'Rue', last_name: 'Zheng')
-      customer3 = Customer.create!(first_name: 'Eric', last_name: 'Espindola')
-      invoice1 = Invoice.create!(customer_id: customer1.id, status: 2)
-      invoice2 = Invoice.create!(customer_id: customer1.id, status: 2)
-      invoice3 = Invoice.create!(customer_id: customer1.id, status: 2)
-      invoice4 = Invoice.create!(customer_id: customer2.id, status: 2)
-      invoice5 = Invoice.create!(customer_id: customer2.id, status: 2)
-      invoice6 = Invoice.create!(customer_id: customer3.id, status: 2)
-      transaction1 = Transaction.create!(invoice_id: invoice1.id, credit_card_number: 4654405418249632, credit_card_expiration_date: "2/22", result: true, created_at: "2012-03-27 14:54:09 UTC")
-      transaction2 = Transaction.create!(invoice_id: invoice2.id, credit_card_number: 4580251236515201, credit_card_expiration_date: "1/22", result: true, created_at: "2012-03-27 14:54:09 UTC")
-      transaction3 = Transaction.create!(invoice_id: invoice3.id, credit_card_number: 4354495077693036, credit_card_expiration_date: "10/22", result: true, created_at: "2012-03-27 14:54:10 UTC")
-      transaction4 = Transaction.create!(invoice_id: invoice4.id, credit_card_number: 4515551623735607, credit_card_expiration_date: "4/25", result: true, created_at: "2012-03-27 14:54:10 UTC")
-      transaction5 = Transaction.create!(invoice_id: invoice5.id, credit_card_number: 4844518708741275, credit_card_expiration_date: "4/23", result: true, created_at: "2012-03-27 14:54:10 UTC")
-      transaction6 = Transaction.create!(invoice_id: invoice6.id, credit_card_number: 4203696133194408, credit_card_expiration_date: "5/22", result: true, created_at: "2012-03-27 14:54:10 UTC")
-
-      all_favorite_customers = Customer.favorite_customers(3)
-
-      expect(all_favorite_customers.first.first_name).to eq('Zach')
-      expect(all_favorite_customers.first.last_name).to eq('Hazelwood')
-      expect(all_favorite_customers.first.count).to eq(3)
-      expect(all_favorite_customers.second.first_name).to eq('Rue')
-      expect(all_favorite_customers.second.last_name).to eq('Zheng')
-      expect(all_favorite_customers.second.count).to eq(2)
-      expect(all_favorite_customers.last.first_name).to eq('Eric')
-      expect(all_favorite_customers.last.last_name).to eq('Espindola')
-      expect(all_favorite_customers.last.count).to eq(1)
-    end
-  end
-
-  describe "::count_successful_transactions" do
-    it "counts the number of a customer's successful transactions" do
-      customer1 = Customer.create!(first_name: 'Zach', last_name: 'Hazelwood')
-      customer2 = Customer.create!(first_name: 'Rue', last_name: 'Zheng')
-      customer3 = Customer.create!(first_name: 'Eric', last_name: 'Espindola')
-      invoice1 = Invoice.create!(customer_id: customer1.id, status: 2)
-      invoice2 = Invoice.create!(customer_id: customer1.id, status: 2)
-      invoice3 = Invoice.create!(customer_id: customer1.id, status: 2)
-      invoice4 = Invoice.create!(customer_id: customer2.id, status: 2)
-      invoice5 = Invoice.create!(customer_id: customer2.id, status: 2)
-      invoice6 = Invoice.create!(customer_id: customer3.id, status: 2)
-      transaction1 = Transaction.create!(invoice_id: invoice1.id, credit_card_number: 4654405418249632, credit_card_expiration_date: "2/22", result: true, created_at: "2012-03-27 14:54:09 UTC")
-      transaction2 = Transaction.create!(invoice_id: invoice2.id, credit_card_number: 4580251236515201, credit_card_expiration_date: "1/22", result: true, created_at: "2012-03-27 14:54:09 UTC")
-      transaction3 = Transaction.create!(invoice_id: invoice3.id, credit_card_number: 4354495077693036, credit_card_expiration_date: "10/22", result: true, created_at: "2012-03-27 14:54:10 UTC")
-      transaction4 = Transaction.create!(invoice_id: invoice4.id, credit_card_number: 4515551623735607, credit_card_expiration_date: "4/25", result: true, created_at: "2012-03-27 14:54:10 UTC")
-      transaction5 = Transaction.create!(invoice_id: invoice5.id, credit_card_number: 4844518708741275, credit_card_expiration_date: "4/23", result: true, created_at: "2012-03-27 14:54:10 UTC")
-      transaction6 = Transaction.create!(invoice_id: invoice6.id, credit_card_number: 4203696133194408, credit_card_expiration_date: "5/22", result: true, created_at: "2012-03-27 14:54:10 UTC")
-
-      expect(Customer.count_successful_transactions(customer1.id)).to eq(3)
-      expect(Customer.count_successful_transactions(customer2.id)).to eq(2)
-      expect(Customer.count_successful_transactions(customer3.id)).to eq(1)
-    end
-  end
-
-  describe "test object block - need to make test objects consistent later" do
+  describe "class methods" do
     let!(:merchant_1) {Merchant.create!(name: "REI")}
     let!(:merchant_2) {Merchant.create!(name: "Target")}
 
@@ -142,10 +86,8 @@ RSpec.describe Customer do
     let!(:transaction21) { Transaction.create!(invoice_id: invoice21.id, credit_card_number: 4801647818676136, credit_card_expiration_date: "5/23", result: "success") }
     let!(:transaction22) { Transaction.create!(invoice_id: invoice22.id, credit_card_number: 4801647818676136, credit_card_expiration_date: "5/23", result: "success") }
 
-    describe "::top_customers" do
-      it "returns the top 5 customers with the highest count of successful transactions" do
-        expect(Customer.top_customers).to eq([customer1, customer4, customer5, customer6, customer2])
-      end
+    it ".top_customers" do
+      expect(Customer.top_customers).to eq([customer1, customer4, customer5, customer6, customer2])
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -24,8 +24,7 @@ RSpec.describe Merchant do
     let!(:item5) {merchant_1.items.create!(name: "Nalgene", description: "Put all your cool stickers here", unit_price: 12)}
     let!(:item6) {merchant_1.items.create!(name: "Fanny Pack", description: "Forget what the haters say, they're stylish", unit_price: 25)}
     let!(:item7) {merchant_1.items.create!(name: "Mountain Bike", description: "Shred the gnar!!", unit_price: 1199)}
-
-    let!(:item8) {merchant_2.items.create!(name: "Conditioner", description: "Bye slit ends!", unit_price: 7)}
+    let!(:item8) {merchant_2.items.create!(name: "Conditioner", description: "Bye split ends!", unit_price: 7)}
 
     let!(:customer1) { Customer.create!(first_name: "Leanne", last_name: "Braun") }
     let!(:customer2) { Customer.create!(first_name: "Sylvester", last_name: "Nader") }
@@ -60,90 +59,25 @@ RSpec.describe Merchant do
     let!(:transaction6) { Transaction.create!(invoice_id: invoice5.id, credit_card_number: 4203696133194408, credit_card_expiration_date: "5/22", result: "success") }
     let!(:transaction7) { Transaction.create!(invoice_id: invoice6.id, credit_card_number: 4801647818676136, credit_card_expiration_date: "5/23", result: "failed") }
 
-    describe '#top_five_items' do
-      it "lists the top five items ordered in highest to lowest revenue" do
-        expect(merchant_1.top_five_items).to eq([item1, item2, item6, item3, item4])
-      end
+    it "#top_five_items" do
+      expect(merchant_1.top_five_items).to eq([item1, item2, item6, item3, item4])
     end
 
-  let!(:merchant_1) {Merchant.create!(name: "REI")}
-  let!(:merchant_2) {Merchant.create!(name: "Target")}
-
-  let!(:item1) {merchant_1.items.create!(name: "Boots", description: "Never get blisters again!", unit_price: 135)}
-  let!(:item2) {merchant_1.items.create!(name: "Tent", description: "Will survive any storm", unit_price: 219.99)}
-  let!(:item3) {merchant_1.items.create!(name: "Backpack", description: "Can carry all your hiking snacks", unit_price: 99)}
-  let!(:item4) {merchant_1.items.create!(name: "Socks", description: "Oooooh, wool", unit_price: 15)}
-  let!(:item5) {merchant_1.items.create!(name: "Nalgene", description: "Put all your cool stickers here", unit_price: 12)}
-  let!(:item6) {merchant_1.items.create!(name: "Fanny Pack", description: "Forget what the haters say, they're stylish", unit_price: 25)}
-  let!(:item7) {merchant_1.items.create!(name: "Mountain Bike", description: "Shred the gnar!!", unit_price: 1199)}
-  let!(:item8) {merchant_2.items.create!(name: "Conditioner", description: "Bye slit ends!", unit_price: 7)}
-
-  let!(:customer1) { Customer.create!(first_name: "Leanne", last_name: "Braun") }
-  let!(:customer2) { Customer.create!(first_name: "Sylvester", last_name: "Nader") }
-  let!(:customer3) { Customer.create!(first_name: "Heber", last_name: "Kuhn") }
-  let!(:customer4) { Customer.create!(first_name: "Mariah", last_name: "Toy") }
-  let!(:customer5) { Customer.create!(first_name: "Carl", last_name: "Junior") }
-  let!(:customer6) { Customer.create!(first_name: "Tony", last_name: "Bologna") }
-
-  let!(:invoice1) { customer1.invoices.create!(status: 2) }
-  let!(:invoice2) { customer2.invoices.create!(status: 2) }
-  let!(:invoice3) { customer3.invoices.create!(status: 2) }
-  let!(:invoice4) { customer4.invoices.create!(status: 2) }
-  let!(:invoice5) { customer5.invoices.create!(status: 2) }
-  let!(:invoice6) { customer6.invoices.create!(status: 2) }
-
-  let!(:invoice_item1) { InvoiceItem.create!(item_id: item1.id, invoice_id: invoice1.id, quantity: 5, unit_price: 130, status: "packaged") }
-  let!(:invoice_item2) { InvoiceItem.create!(item_id: item1.id, invoice_id: invoice2.id, quantity: 10, unit_price: 130, status: "pending") }
-  let!(:invoice_item3) { InvoiceItem.create!(item_id: item2.id, invoice_id: invoice3.id, quantity: 8, unit_price: 220, status: "packaged") }
-  let!(:invoice_item4) { InvoiceItem.create!(item_id: item3.id, invoice_id: invoice4.id, quantity: 1, unit_price: 100, status: "packaged") }
-  let!(:invoice_item5) { InvoiceItem.create!(item_id: item4.id, invoice_id: invoice5.id, quantity: 2, unit_price: 15, status: "shipped") }
-  let!(:invoice_item6) { InvoiceItem.create!(item_id: item5.id, invoice_id: invoice6.id, quantity: 3, unit_price: 12, status: "packaged") }
-  let!(:invoice_item7) { InvoiceItem.create!(item_id: item4.id, invoice_id: invoice6.id, quantity: 1, unit_price: 16, status: "packaged") }
-  let!(:invoice_item8) { InvoiceItem.create!(item_id: item5.id, invoice_id: invoice5.id, quantity: 2, unit_price: 12, status: "pending") }
-  let!(:invoice_item9) { InvoiceItem.create!(item_id: item6.id, invoice_id: invoice1.id, quantity: 4, unit_price: 35, status: "packaged") }
-  let!(:invoice_item10) { InvoiceItem.create!(item_id: item7.id, invoice_id: invoice4.id, quantity: 1, unit_price: 35, status: "packaged") }
-
-  let!(:transaction1) { Transaction.create!(invoice_id: invoice1.id, credit_card_number: 4654405418249632, credit_card_expiration_date: "2/22", result: "success") }
-  let!(:transaction2) { Transaction.create!(invoice_id: invoice2.id, credit_card_number: 4580251236515201, credit_card_expiration_date: "1/22", result: "success") }
-  let!(:transaction3) { Transaction.create!(invoice_id: invoice3.id, credit_card_number: 4354495077693036, credit_card_expiration_date: "10/22", result: "success") }
-  let!(:transaction4) { Transaction.create!(invoice_id: invoice4.id, credit_card_number: 4515551623735607, credit_card_expiration_date: "4/25", result: "success") }
-  let!(:transaction5) { Transaction.create!(invoice_id: invoice5.id, credit_card_number: 4844518708741275, credit_card_expiration_date: "4/23", result: "success") }
-  let!(:transaction6) { Transaction.create!(invoice_id: invoice5.id, credit_card_number: 4203696133194408, credit_card_expiration_date: "5/22", result: "success") }
-  let!(:transaction7) { Transaction.create!(invoice_id: invoice6.id, credit_card_number: 4801647818676136, credit_card_expiration_date: "5/23", result: "failed") }
-
-  describe '#items_ready_to_ship' do
-    it 'items_ready_to_ship should return array of items ready to ship ordered by invoice date' do
-      merchant1 = Merchant.create!(name: "Schroeder-Jerde")
-
-      item1 = merchant1.items.create!(name: "Qui Esse", description: "Nihil autem sit odio inventore deleniti", unit_price: 75107)
-      item2 = merchant1.items.create!(name: "Autem Minima", description: "Cumque consequuntur ad", unit_price: 67076)
-
-      customer1 = Customer.create!(first_name: "Leanne", last_name: "Braun")
-      customer2 = Customer.create!(first_name: "Sylvester", last_name: "Nader")
-      customer3 = Customer.create!(first_name: "Heber", last_name: "Kuhn")
-
-      invoice2 = customer2.invoices.create!(status: "completed")
-      invoice3 = customer3.invoices.create!(status: "in progress")
-      invoice4 = customer2.invoices.create!(status: "completed")
-      invoice5 = customer1.invoices.create!(status: "completed")
-      invoice1 = customer1.invoices.create!(status: "in progress")
-
-      invoice_item1 = InvoiceItem.create!(item_id: item1.id, invoice_id: invoice1.id, quantity: 5, unit_price: 13635, status: "packaged")
-      invoice_item2 = InvoiceItem.create!(item_id: item1.id, invoice_id: invoice2.id, quantity: 9, unit_price: 23324, status: "pending")
-      invoice_item3 = InvoiceItem.create!(item_id: item2.id, invoice_id: invoice3.id, quantity: 8, unit_price: 34873, status: "packaged")
-      invoice_item4 = InvoiceItem.create!(item_id: item2.id, invoice_id: invoice4.id, quantity: 3, unit_price: 2196, status: "packaged")
-      invoice_item5 = InvoiceItem.create!(item_id: item2.id, invoice_id: invoice5.id, quantity: 7, unit_price: 79140, status: "shipped")
-
-      transaction1 = Transaction.create!(invoice_id: invoice1.id, credit_card_number: 4654405418249632, credit_card_expiration_date: "2/22", result: "success")
-      transaction2 = Transaction.create!(invoice_id: invoice2.id, credit_card_number: 4580251236515201, credit_card_expiration_date: "1/22", result: "failed")
-      transaction3 = Transaction.create!(invoice_id: invoice3.id, credit_card_number: 4354495077693036, credit_card_expiration_date: "10/22", result: "success")
-      transaction4 = Transaction.create!(invoice_id: invoice4.id, credit_card_number: 4515551623735607, credit_card_expiration_date: "4/25", result: "success")
-      transaction5 = Transaction.create!(invoice_id: invoice5.id, credit_card_number: 4844518708741275, credit_card_expiration_date: "4/23", result: "success")
-
-      expect(merchant1.items_ready_to_ship.first.id).to eq(invoice3.id)
-      expect(merchant1.items_ready_to_ship.first.name).to eq("#{item2.name}")
-      expect(merchant1.items_ready_to_ship.first.created_at).to eq(invoice3.created_at)
+    it '#items_ready_to_ship' do
+      expect(merchant_1.items_ready_to_ship.first.id).to eq(invoice1.id)
+      expect(merchant_1.items_ready_to_ship.first.name).to eq("Boots")
+      expect(merchant_1.items_ready_to_ship.first.created_at).to eq(invoice1.created_at)
     end
-  end
+
+    it "#top_five_favorite_customers" do
+      expect(merchant_1.top_five_favorite_customers).to eq([customer5, customer1, customer4, customer2, customer3])
+    end
+
+    it "counts the number of successful transactions of a customer" do
+      test_customers = merchant_1.top_five_favorite_customers
+
+      expect(test_customers[0].transaction_count).to eq(4)
+      expect(test_customers[4].transaction_count).to eq(1)
+    end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -59,25 +59,31 @@ RSpec.describe Merchant do
     let!(:transaction6) { Transaction.create!(invoice_id: invoice5.id, credit_card_number: 4203696133194408, credit_card_expiration_date: "5/22", result: "success") }
     let!(:transaction7) { Transaction.create!(invoice_id: invoice6.id, credit_card_number: 4801647818676136, credit_card_expiration_date: "5/23", result: "failed") }
 
-    it "#top_five_items" do
-      expect(merchant_1.top_five_items).to eq([item1, item2, item6, item3, item4])
+    describe '#top_five_items' do
+      it "lists the top five items ordered in highest to lowest revenue" do
+        expect(merchant_1.top_five_items).to eq([item1, item2, item6, item3, item4])
+      end
     end
 
-    it '#items_ready_to_ship' do
-      expect(merchant_1.items_ready_to_ship.first.id).to eq(invoice1.id)
-      expect(merchant_1.items_ready_to_ship.first.name).to eq("Boots")
-      expect(merchant_1.items_ready_to_ship.first.created_at).to eq(invoice1.created_at)
+    describe '#items_ready_to_ship' do
+      it 'returns an array of items ready to ship ordered by invoice date' do
+        expect(merchant_1.items_ready_to_ship.first.id).to eq(invoice1.id)
+        expect(merchant_1.items_ready_to_ship.first.name).to eq("Boots")
+        expect(merchant_1.items_ready_to_ship.first.created_at).to eq(invoice1.created_at)
+      end
     end
 
-    it "#top_five_favorite_customers" do
-      expect(merchant_1.top_five_favorite_customers).to eq([customer5, customer1, customer4, customer2, customer3])
-    end
+    describe '#top_five_favorite_customers'
+      it "returns an array of the customers with the most transactions from the merchant" do
+        expect(merchant_1.top_five_favorite_customers).to eq([customer5, customer1, customer4, customer2, customer3])
+      end
 
-    it "counts the number of successful transactions of a customer" do
-      test_customers = merchant_1.top_five_favorite_customers
+      it "counts the number of successful transactions of a customer" do
+        test_customers = merchant_1.top_five_favorite_customers
 
-      expect(test_customers[0].transaction_count).to eq(4)
-      expect(test_customers[4].transaction_count).to eq(1)
+        expect(test_customers[0].transaction_count).to eq(4)
+        expect(test_customers[4].transaction_count).to eq(1)
+      end
     end
   end
 end


### PR DESCRIPTION
### What does this PR do?
- Completes US #38 again with the correct model method and display information. Previously, the method was returning the Top Customers from all available tables. Now, it correctly displays only the customers who have made successful transaction purchases of the respective Merchant's products.
- A similar method still exists within the Customer model, but that method correctly displays Customers with the highest number of transactions, in total, and not just limited to any one Merchant.
- Removes several `save_and_open_page`
- Removes unused methods from `Customer` that have been refactored and their associated model tests
- Refactors `merchant_spec.rb` to remove extra/unnecessary data and lines

### All tests passing?
- [X] Yes
- [ ] No

### SimpleCov 100%?
- [X] Yes
- [ ] No
- If No, what's missing:

### Has this been tested on LOCALHOST?
- [X] Yes - and verified through `rails c` to determine the data matches
- [ ] No
- Did something not work? If so, what was it?
