### PR TITLE
Admin merchant update

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -7,4 +7,16 @@ class Admin::InvoicesController < ApplicationController
   def show
     @invoice = Invoice.find(params[:id])
   end
+
+  def update
+    invoice = Invoice.find(params[:id])
+    invoice_item = InvoiceItem.find(params[:invoice_item_id])
+    invoice_item.update(invoice_item_params)
+    redirect_to admin_invoice_path(invoice)
+  end
+
+  private
+    def invoice_item_params
+      params.permit(:status)
+    end
 end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -16,8 +16,26 @@ class Admin::MerchantsController < ApplicationController
 
   def update
     merchant = Merchant.find(params[:id])
-    merchant.update(params.permit(:name))
-    flash[:notice] = "You have successfully updated this Merchant!"
-    redirect_to admin_merchant_path(merchant)
+    if params[:status]
+      merchant.update(merchant_status_params)
+      redirect_to admin_merchants_path
+    else
+      if merchant.update(merchant_params)
+        flash[:notice] = "You have successfully updated this Merchant!"
+        redirect_to admin_merchant_path(merchant)
+      else
+        flash[:notice] = "Please fill out all fields to update this Merchant!"
+        redirect_to edit_admin_merchant_path(merchant)
+      end
+    end
   end
+
+  private
+    def merchant_params
+      params.permit(:name)
+    end
+
+    def merchant_status_params
+      params.permit(:status)
+    end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -15,6 +15,11 @@
     <p>Quantity Sold: <%= invoice_item.quantity %></p>
     <p>Sold at: <%= number_to_currency(invoice_item.unit_price) %></p>
     <p>Invoice Item Status: <%= invoice_item.status.titleize %></p>
+    <%= form_with url: admin_invoice_path(@invoice), method: :patch do |form| %>
+      <%= form.select :status, ['pending', 'shipped', 'packaged'], selected: invoice_item.status %>
+      <%= hidden_field_tag "invoice_item_id", "#{invoice_item.id}" %>
+      <%= form.submit "Update Invoice Item Status" %>
+    <% end %>
   </div>
   <hr>
   <% end %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -5,13 +5,19 @@
 <div class="enabled-merchants">
   <h3> Status: Enabled </h3>
   <ul><% @enabled_merchants.each do |merchant| %>
-    <li><%= merchant.name %></li>
+    <div id="enabled-merchants-<%= merchant.id %>">
+    <li><%= link_to "#{merchant.name}", admin_merchant_path(merchant) %>
+    <%= button_to "Disable", admin_merchant_path(merchant), method: :patch, params: { status: 'disabled' } %></li>
+    </div>
   <% end %></ul>
 </div>
 
 <div class="disabled-merchants">
   <h3> Status: Disabled </h3>
   <ul><% @disabled_merchants.each do |merchant| %>
-    <li><%= merchant.name %></li>
+    <div id="disabled-merchants-<%= merchant.id %>">
+    <li><%= link_to "#{merchant.name}", admin_merchant_path(merchant) %>
+    <%= button_to "Enable", admin_merchant_path(merchant), method: :patch, params: { status: 'enabled' } %></li>
+    </div>
   <% end %></ul>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,6 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :merchants, only: [:index, :show, :update, :edit]
-    resources :invoices, only: [:index, :show]
+    resources :invoices, only: [:index, :show, :update]
   end
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -54,4 +54,21 @@ RSpec.describe "Admin Invoice Show Page" do
 
     expect(page).to have_content("Total Revenue: $278,091.00")
   end
+
+  it "can update and Invoice Item's status via a selector" do
+    visit admin_invoice_path(invoice1)
+
+    within "##{invoice_item1.id}" do
+      select "#{invoice_item1.status}"
+      select "shipped"
+      expect(page).to have_button("Update Invoice Item Status")
+
+      click_button "Update Invoice Item Status"
+      expect(page).to have_select(selected: "shipped")
+      expect(page).to_not have_select(selected: "packaged")
+      expect(page).to_not have_select(selected: "pending")
+    end
+
+    expect(current_path).to eq(admin_invoice_path(invoice1))
+  end
 end

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe "Admin Merchant Show" do
+  let!(:merchant1) { Merchant.create!(name: "REI") }
+
+  before do
+    visit edit_admin_merchant_path(merchant1)
+  end
+
+  it "can click a link to update this merchant and shows a flash message stating the merchant has been successfully updated" do
+    fill_in :name, with: 'Black Diamond'
+    click_on "Submit"
+
+    expect(current_path).to eq(admin_merchant_path(merchant1))
+    expect(page).to have_content('Black Diamond')
+    expect(page).to have_content('You have successfully updated this Merchant!')
+  end
+
+  it "displays a message if fields aren't updated" do
+    fill_in :name, with: nil
+    click_on "Submit"
+
+    expect(current_path).to eq(edit_admin_merchant_path(merchant1))
+    expect(page).to have_content('Please fill out all fields to update this Merchant!')
+  end
+end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe "Admin Merchants Index Page" do
-  it "displays the name of each merchant in the system" do
-    merchant1 = Merchant.create!(name: "REI")
-    merchant2 = Merchant.create!(name: "Target")
-    merchant3 = Merchant.create!(name: "Walgreens")
-    merchant4 = Merchant.create!(name: "Hot Topic", status: 1)
+  let!(:merchant1) { Merchant.create!(name: "REI") }
+  let!(:merchant2) { Merchant.create!(name: "Target") }
+  let!(:merchant3) { Merchant.create!(name: "Walgreens") }
+  let!(:merchant4) { Merchant.create!(name: "Hot Topic", status: 1) }
 
+  it "displays the name of each merchant in the system" do
     visit admin_merchants_path
-    
+
     expect(page).to have_content("Admin Merchants Index")
 
     within ".disabled-merchants" do
@@ -23,6 +23,60 @@ RSpec.describe "Admin Merchants Index Page" do
       expect(page).to_not have_content("REI")
       expect(page).to_not have_content("Target")
       expect(page).to_not have_content("Walgreens")
+    end
+  end
+
+  it "has a link to each Merchant's Admin Show page" do
+    visit admin_merchants_path
+
+    within "#enabled-merchants-#{merchant4.id}" do
+      expect(page).to have_link("Hot Topic")
+      expect(page).to_not have_link("Target")
+      click_link ("Hot Topic")
+    end
+
+    expect(current_path).to eq(admin_merchant_path(merchant4))
+
+    visit admin_merchants_path
+
+    within "#disabled-merchants-#{merchant1.id}" do
+      expect(page).to have_link("REI")
+      expect(page).to_not have_link("Hot Topic")
+      click_link ("REI")
+    end
+
+    expect(current_path).to eq(admin_merchant_path(merchant1))
+  end
+
+  it "has a button to enable/disable a merchant" do
+    visit admin_merchants_path
+
+    within "#enabled-merchants-#{merchant4.id}" do
+      expect(page).to have_link("Hot Topic")
+      expect(page).to_not have_link("Target")
+      expect(page).to have_button("Disable")
+      expect(page).to_not have_button("Enable")
+      click_button ("Disable")
+    end
+
+    within "#disabled-merchants-#{merchant1.id}" do
+      expect(page).to have_link("REI")
+      expect(page).to_not have_link("Hot Topic")
+      expect(page).to have_button("Enable")
+      expect(page).to_not have_button("Disable")
+      click_button ("Enable")
+    end
+
+    visit admin_merchants_path
+
+    within ".enabled-merchants" do
+      expect(page).to_not have_link("Hot Topic")
+      expect(page).to have_link("REI")
+    end
+
+    within ".disabled-merchants" do
+      expect(page).to_not have_link("REI")
+      expect(page).to have_link("Hot Topic")
     end
   end
 end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -15,12 +15,5 @@ RSpec.describe "Admin Merchant Show" do
     click_link "Update Merchant"
 
     expect(current_path).to eq(edit_admin_merchant_path(merchant1))
-
-    fill_in :name, with: 'Black Diamond'
-    click_on "Submit"
-    
-    expect(current_path).to eq(admin_merchant_path(merchant1))
-    expect(page).to have_content('Black Diamond')
-    expect(page).to have_content('You have successfully updated this Merchant!')
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -13,63 +13,76 @@ RSpec.describe Merchant do
     it { should validate_presence_of(:name) }
   end
 
-  describe 'instance methods' do
+  let!(:merchant_1) {Merchant.create!(name: "REI")}
+  let!(:merchant_2) {Merchant.create!(name: "Target", status: 1)}
 
-    let!(:merchant_1) {Merchant.create!(name: "REI")}
-    let!(:merchant_2) {Merchant.create!(name: "Target")}
+  let!(:item1) {merchant_1.items.create!(name: "Boots", description: "Never get blisters again!", unit_price: 135)}
+  let!(:item2) {merchant_1.items.create!(name: "Tent", description: "Will survive any storm", unit_price: 219.99)}
+  let!(:item3) {merchant_1.items.create!(name: "Backpack", description: "Can carry all your hiking snacks", unit_price: 99)}
+  let!(:item4) {merchant_1.items.create!(name: "Socks", description: "Oooooh, wool", unit_price: 15)}
+  let!(:item5) {merchant_1.items.create!(name: "Nalgene", description: "Put all your cool stickers here", unit_price: 12)}
+  let!(:item6) {merchant_1.items.create!(name: "Fanny Pack", description: "Forget what the haters say, they're stylish", unit_price: 25)}
+  let!(:item7) {merchant_1.items.create!(name: "Mountain Bike", description: "Shred the gnar!!", unit_price: 1199)}
+  let!(:item8) {merchant_2.items.create!(name: "Conditioner", description: "Bye split ends!", unit_price: 7)}
 
-    let!(:item1) {merchant_1.items.create!(name: "Boots", description: "Never get blisters again!", unit_price: 135)}
-    let!(:item2) {merchant_1.items.create!(name: "Tent", description: "Will survive any storm", unit_price: 219.99)}
-    let!(:item3) {merchant_1.items.create!(name: "Backpack", description: "Can carry all your hiking snacks", unit_price: 99)}
-    let!(:item4) {merchant_1.items.create!(name: "Socks", description: "Oooooh, wool", unit_price: 15)}
-    let!(:item5) {merchant_1.items.create!(name: "Nalgene", description: "Put all your cool stickers here", unit_price: 12)}
-    let!(:item6) {merchant_1.items.create!(name: "Fanny Pack", description: "Forget what the haters say, they're stylish", unit_price: 25)}
-    let!(:item7) {merchant_1.items.create!(name: "Mountain Bike", description: "Shred the gnar!!", unit_price: 1199)}
-    let!(:item8) {merchant_2.items.create!(name: "Conditioner", description: "Bye split ends!", unit_price: 7)}
+  let!(:customer1) { Customer.create!(first_name: "Leanne", last_name: "Braun") }
+  let!(:customer2) { Customer.create!(first_name: "Sylvester", last_name: "Nader") }
+  let!(:customer3) { Customer.create!(first_name: "Heber", last_name: "Kuhn") }
+  let!(:customer4) { Customer.create!(first_name: "Mariah", last_name: "Toy") }
+  let!(:customer5) { Customer.create!(first_name: "Carl", last_name: "Junior") }
+  let!(:customer6) { Customer.create!(first_name: "Tony", last_name: "Bologna") }
 
-    let!(:customer1) { Customer.create!(first_name: "Leanne", last_name: "Braun") }
-    let!(:customer2) { Customer.create!(first_name: "Sylvester", last_name: "Nader") }
-    let!(:customer3) { Customer.create!(first_name: "Heber", last_name: "Kuhn") }
-    let!(:customer4) { Customer.create!(first_name: "Mariah", last_name: "Toy") }
-    let!(:customer5) { Customer.create!(first_name: "Carl", last_name: "Junior") }
-    let!(:customer6) { Customer.create!(first_name: "Tony", last_name: "Bologna") }
+  let!(:invoice1) { customer1.invoices.create!(status: 2) }
+  let!(:invoice2) { customer2.invoices.create!(status: 2) }
+  let!(:invoice3) { customer3.invoices.create!(status: 2) }
+  let!(:invoice4) { customer4.invoices.create!(status: 2) }
+  let!(:invoice5) { customer5.invoices.create!(status: 2) }
+  let!(:invoice6) { customer6.invoices.create!(status: 2) }
 
-    let!(:invoice1) { customer1.invoices.create!(status: 2) }
-    let!(:invoice2) { customer2.invoices.create!(status: 2) }
-    let!(:invoice3) { customer3.invoices.create!(status: 2) }
-    let!(:invoice4) { customer4.invoices.create!(status: 2) }
-    let!(:invoice5) { customer5.invoices.create!(status: 2) }
-    let!(:invoice6) { customer6.invoices.create!(status: 2) }
+  let!(:invoice_item1) { InvoiceItem.create!(item_id: item1.id, invoice_id: invoice1.id, quantity: 5, unit_price: 130, status: "packaged") }
+  let!(:invoice_item2) { InvoiceItem.create!(item_id: item1.id, invoice_id: invoice2.id, quantity: 10, unit_price: 130, status: "pending") }
+  let!(:invoice_item3) { InvoiceItem.create!(item_id: item2.id, invoice_id: invoice3.id, quantity: 8, unit_price: 220, status: "packaged") }
+  let!(:invoice_item4) { InvoiceItem.create!(item_id: item3.id, invoice_id: invoice4.id, quantity: 1, unit_price: 100, status: "packaged") }
+  let!(:invoice_item5) { InvoiceItem.create!(item_id: item4.id, invoice_id: invoice5.id, quantity: 2, unit_price: 15, status: "shipped") }
+  let!(:invoice_item6) { InvoiceItem.create!(item_id: item5.id, invoice_id: invoice6.id, quantity: 3, unit_price: 12, status: "packaged") }
+  let!(:invoice_item7) { InvoiceItem.create!(item_id: item4.id, invoice_id: invoice6.id, quantity: 1, unit_price: 16, status: "packaged") }
+  let!(:invoice_item8) { InvoiceItem.create!(item_id: item5.id, invoice_id: invoice5.id, quantity: 2, unit_price: 12, status: "pending") }
+  let!(:invoice_item9) { InvoiceItem.create!(item_id: item6.id, invoice_id: invoice1.id, quantity: 4, unit_price: 35, status: "packaged") }
+  let!(:invoice_item10) { InvoiceItem.create!(item_id: item7.id, invoice_id: invoice4.id, quantity: 1, unit_price: 35, status: "packaged") }
 
-    let!(:invoice_item1) { InvoiceItem.create!(item_id: item1.id, invoice_id: invoice1.id, quantity: 5, unit_price: 130, status: "packaged") }
-    let!(:invoice_item2) { InvoiceItem.create!(item_id: item1.id, invoice_id: invoice2.id, quantity: 10, unit_price: 130, status: "pending") }
-    let!(:invoice_item3) { InvoiceItem.create!(item_id: item2.id, invoice_id: invoice3.id, quantity: 8, unit_price: 220, status: "packaged") }
-    let!(:invoice_item4) { InvoiceItem.create!(item_id: item3.id, invoice_id: invoice4.id, quantity: 1, unit_price: 100, status: "packaged") }
-    let!(:invoice_item5) { InvoiceItem.create!(item_id: item4.id, invoice_id: invoice5.id, quantity: 2, unit_price: 15, status: "shipped") }
-    let!(:invoice_item6) { InvoiceItem.create!(item_id: item5.id, invoice_id: invoice6.id, quantity: 3, unit_price: 12, status: "packaged") }
-    let!(:invoice_item7) { InvoiceItem.create!(item_id: item4.id, invoice_id: invoice6.id, quantity: 1, unit_price: 16, status: "packaged") }
-    let!(:invoice_item8) { InvoiceItem.create!(item_id: item5.id, invoice_id: invoice5.id, quantity: 2, unit_price: 12, status: "pending") }
-    let!(:invoice_item9) { InvoiceItem.create!(item_id: item6.id, invoice_id: invoice1.id, quantity: 4, unit_price: 35, status: "packaged") }
-    let!(:invoice_item10) { InvoiceItem.create!(item_id: item7.id, invoice_id: invoice4.id, quantity: 1, unit_price: 35, status: "packaged") }
+  let!(:transaction1) { Transaction.create!(invoice_id: invoice1.id, credit_card_number: 4654405418249632, credit_card_expiration_date: "2/22", result: "success") }
+  let!(:transaction2) { Transaction.create!(invoice_id: invoice2.id, credit_card_number: 4580251236515201, credit_card_expiration_date: "1/22", result: "success") }
+  let!(:transaction3) { Transaction.create!(invoice_id: invoice3.id, credit_card_number: 4354495077693036, credit_card_expiration_date: "10/22", result: "success") }
+  let!(:transaction4) { Transaction.create!(invoice_id: invoice4.id, credit_card_number: 4515551623735607, credit_card_expiration_date: "4/25", result: "success") }
+  let!(:transaction5) { Transaction.create!(invoice_id: invoice5.id, credit_card_number: 4844518708741275, credit_card_expiration_date: "4/23", result: "success") }
+  let!(:transaction6) { Transaction.create!(invoice_id: invoice5.id, credit_card_number: 4203696133194408, credit_card_expiration_date: "5/22", result: "success") }
+  let!(:transaction7) { Transaction.create!(invoice_id: invoice6.id, credit_card_number: 4801647818676136, credit_card_expiration_date: "5/23", result: "failed") }
 
-    let!(:transaction1) { Transaction.create!(invoice_id: invoice1.id, credit_card_number: 4654405418249632, credit_card_expiration_date: "2/22", result: "success") }
-    let!(:transaction2) { Transaction.create!(invoice_id: invoice2.id, credit_card_number: 4580251236515201, credit_card_expiration_date: "1/22", result: "success") }
-    let!(:transaction3) { Transaction.create!(invoice_id: invoice3.id, credit_card_number: 4354495077693036, credit_card_expiration_date: "10/22", result: "success") }
-    let!(:transaction4) { Transaction.create!(invoice_id: invoice4.id, credit_card_number: 4515551623735607, credit_card_expiration_date: "4/25", result: "success") }
-    let!(:transaction5) { Transaction.create!(invoice_id: invoice5.id, credit_card_number: 4844518708741275, credit_card_expiration_date: "4/23", result: "success") }
-    let!(:transaction6) { Transaction.create!(invoice_id: invoice5.id, credit_card_number: 4203696133194408, credit_card_expiration_date: "5/22", result: "success") }
-    let!(:transaction7) { Transaction.create!(invoice_id: invoice6.id, credit_card_number: 4801647818676136, credit_card_expiration_date: "5/23", result: "failed") }
+  describe 'class methods' do
+    describe '#enabled' do
+      it "returns all merchants with a status set to enabled" do
+        expect(Merchant.enabled).to eq([merchant_2])
+      end
+    end
 
-  describe '#top_five_items' do
-    it "lists the top five items ordered in highest to lowest revenue" do
-      expect(merchant_1.top_five_items).to eq([item1, item2, item6, item3, item4])
+    describe '#disabled' do
+      it "returns all merchants with a status set to disabled" do
+        expect(Merchant.disabled).to eq([merchant_1])
+      end
     end
   end
 
-  # describe '#top_date_by_revenue' do
-    #   it "returns the date with the most revenue for each merchant" do
-    #   end
-  # end
+  describe 'instance methods' do
+    describe '#top_five_items' do
+      it "lists the top five items ordered in highest to lowest revenue" do
+        expect(merchant_1.top_five_items).to eq([item1, item2, item6, item3, item4])
+      end
+    end
+
+    # describe '#top_date_by_revenue' do
+      #   it "returns the date with the most revenue for each merchant" do
+      #   end
+    # end
 
   describe '#items_ready_to_ship' do
     it 'returns an array of items ready to ship ordered by invoice date' do


### PR DESCRIPTION
### What does this PR do?
- Completes User Story #14 - Admin Merchants Index now show buttons beneath each Merchant's name to Enable or Disable their status, depending on it's current status; can only Enable disabled Merchants and vice versa
- Designates Merchant names as links to their Show pages, as this functionality was missing from its User Story #16, which was totally my fault for missing that requirement within the story
- Relocates `Update Merchant` test from `spec/features/admin/merchants/show_spec.rb` to `spec/features/admin/merchants/edit_spec.rb,` as the actual updates occur from the edit page
- Adds test for `edit_spec.rb` to test for a missing update field. Since the only this to update is the name, and the field is auto-filled with the Merchant's current name, the test uses `fill_in :name, with: nil` to mock an empty text field. This was done to keep SimpleCov at 100%
- Had to copy-paste 'spec/models/merchant_spec.rb` as my file didn't update when pulling from `almost-main`

### All tests passing?
- [X] Yes
- [ ] No

### SimpleCov 100%?
- [X] Yes
- [ ] No
- If No, what's missing:

### Has this been tested on LOCALHOST?
- [X] Yes
- [ ] No
- Did something not work? If so, what was it?
